### PR TITLE
Add federated identities

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,27 +1,37 @@
 name: Docker
 
-## add something in here to choose when this workflow runs
 on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       tag:
         description: 'Tag to use (defaults to "test")'
-        default: "test"
-#  push:
-#    branches:
-#      - main
+        default: 'test'
 
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 env:
   VERSION: 0.1.0
+  # TODO(you) choose the name for your image
+  IMAGE_NAME: cpg-flow-gatk-sv
+  DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
+  DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images
 
 jobs:
-  docker:
+  docker-dev:
+    name: Build & Push to Dev
     runs-on: ubuntu-latest
-    environment: production
+    if: |
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'workflow_dispatch' && github.ref_name != 'main')
+    environment: development
+    permissions:
+      id-token: write
+      contents: read
     defaults:
       run:
         shell: bash -l {0}
@@ -29,21 +39,17 @@ jobs:
       DOCKER_BUILDKIT: 1
       BUILDKIT_PROGRESS: plain
       CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-      # TODO(you) choose the name for your image
-      IMAGE_NAME: workflow_name
-      DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
-      DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images
     steps:
       - uses: actions/checkout@v4
         with:
           lfs: 'true'
 
-      - id: "google-cloud-auth"
-        name: "Authenticate to Google Cloud"
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: "projects/1051897107465/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
-          service_account: "gh-images-deployer@cpg-common.iam.gserviceaccount.com"
+          workload_identity_provider: ${{ secrets.DEV_IMG_DEPLOYER_POOL}}
+          service_account: ${{ secrets.DEV_IMG_DEPLOYER_SA }}
 
       - name: set up gcloud sdk
         uses: google-github-actions/setup-gcloud@v2
@@ -58,21 +64,59 @@ jobs:
         run: |
           docker build . -f Dockerfile --tag $IMAGE_NAME:${{ github.sha }}
 
-      # TODO(you) choose how/when to push the resulting image
-      - name: Push from merge to main
-        if: ${{ github.ref_name == 'main' }}
+      - name: Push Pull Request build
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:$VERSION
-          docker push $DOCKER_MAIN/$IMAGE_NAME:$VERSION
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:PR_${{github.event.number}}
+          docker push $DOCKER_DEV/$IMAGE_NAME:PR_${{github.event.number}}
 
-      - name: Push manually triggered build
+      - name: Push manually triggered dev build
         if: ${{ github.event_name == 'workflow_dispatch' && github.ref_name != 'main' }}
         run: |
           docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}
           docker push $DOCKER_DEV/$IMAGE_NAME:${{github.event.inputs.tag}}
 
-      - name: Push Pull Request triggered build
-        if: ${{ github.event_name == 'pull_request' && github.ref_name != 'main' }}
+  docker-prod:
+    name: Build & Push to Prod
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref_name == 'main'
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    defaults:
+      run:
+        shell: bash -l {0}
+    env:
+      DOCKER_BUILDKIT: 1
+      BUILDKIT_PROGRESS: plain
+      CLOUDSDK_CORE_DISABLE_PROMPTS: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: 'true'
+
+      - id: 'google-cloud-auth'
+        name: 'Authenticate to Google Cloud'
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.PROD_IMG_DEPLOYER_POOL}}
+          service_account: ${{ secrets.PROD_IMG_DEPLOYER_SA }}
+
+      - name: set up gcloud sdk
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: cpg-common
+
+      - name: gcloud docker auth
         run: |
-          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_DEV/$IMAGE_NAME:PR_${{github.event.number}}
-          docker push $DOCKER_DEV/$IMAGE_NAME:PR_${{github.event.number}}
+          gcloud auth configure-docker australia-southeast1-docker.pkg.dev
+
+      - name: build
+        run: |
+          docker build . -f Dockerfile --tag $IMAGE_NAME:${{ github.sha }}
+
+      - name: Push to production
+        run: |
+          docker tag $IMAGE_NAME:${{ github.sha }} $DOCKER_MAIN/$IMAGE_NAME:$VERSION
+          docker push $DOCKER_MAIN/$IMAGE_NAME:$VERSION

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -53,8 +53,6 @@ jobs:
 
       - name: set up gcloud sdk
         uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: cpg-common
 
       - name: gcloud docker auth
         run: |
@@ -105,8 +103,6 @@ jobs:
 
       - name: set up gcloud sdk
         uses: google-github-actions/setup-gcloud@v2
-        with:
-          project_id: cpg-common
 
       - name: gcloud docker auth
         run: |


### PR DESCRIPTION
This splits the docker workflow into two jobs for the two environments that we want to support.

# Purpose

  - Requested by pipeline developer to be able to push images to the registry

## Proposed Changes

  - Split docker workflow into two jobs
  - Scope permissions to the job level
  - Separate credentials for prod and dev environments

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
