### PR TITLE
Pin CPG-Flow to avoid 110

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.1
+  VERSION: 0.1.2
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.1
+Current Version: 0.1.2
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.1 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.2 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers=[
 ]
 
 dependencies=[
-    'cpg-flow>=v0.2.4',
+    'cpg-flow==v0.2.4',
     'elasticsearch',
     'hatchling>=1.27.0',
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.1"
+version="0.1.2"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.1"
+current_version = "0.1.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,8 +129,8 @@ commit_args = ""
 
 [[tool.bumpversion.files]]
 filename = "pyproject.toml"
-search = "version='{current_version}'"
-replace = "version='{new_version}'"
+search = 'version="{current_version}"'
+replace = 'version="{new_version}"'
 
 [[tool.bumpversion.files]]
 filename = ".github/workflows/docker.yaml"


### PR DESCRIPTION
# Purpose

  - A recent linting change to CPG-Flow enforced some false assumptions about expected_outputs formats. This has damaged the ability to run some Cromwell Stages
  - see https://github.com/populationgenomics/cpg-flow/issues/110
  - see https://batch.hail.populationgenomics.org.au/batches/619213/jobs/1 (failed calling `to_path` on a list of Paths)

## Proposed Changes

  - Pins to an earlier version of CPG-Flow, where typecasting was not done on the return from `expected_outputs`