### PR TITLE
Fix for re-use of manta vcf

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.4
+  VERSION: 0.1.5
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.4
+Current Version: 0.1.5
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.4 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.5 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.4"
+version="0.1.5"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.4"
+current_version = "0.1.5"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
+++ b/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, Any
 
-import loguru
-
 from cpg_flow import targets
 from cpg_flow_gatk_sv import utils
 from cpg_utils import Path, config, to_path
@@ -78,14 +76,10 @@ def create_gather_sample_evidence_jobs(
             # if Scramble is being run, but Manta is not, manta_vcf and index becomes a required input
             if to_path(expected_outputs['manta_vcf']).exists():
                 # if the Manta VCF exists, use it as input and remove it from expected outputs
-                loguru.logger.info(f'Re-using existing Manta VCF {expected_outputs["manta_vcf"]} for {sg.id}')
                 input_dict['manta_vcf_input'] = expected_outputs.pop('manta_vcf')
                 input_dict['manta_vcf_index_input'] = expected_outputs.pop('manta_index')
             else:
                 # if the Manta VCF does not exist, run Manta as well
-                loguru.logger.info(
-                    f'Adding Manta job for {sg.id} because Scramble is being run and Manta VCF does not exist'
-                )
                 only_jobs.append('manta')
 
         # disable the caller jobs that are not in only_jobs by nulling their docker image

--- a/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
+++ b/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
+import loguru
+
 from cpg_flow import targets
 from cpg_flow_gatk_sv import utils
 from cpg_utils import Path, config, to_path
@@ -76,10 +78,14 @@ def create_gather_sample_evidence_jobs(
             # if Scramble is being run, but Manta is not, manta_vcf and index becomes a required input
             if to_path(expected_outputs['manta_vcf']).exists():
                 # if the Manta VCF exists, use it as input and remove it from expected outputs
+                loguru.logger.info(f'Re-using existing Manta VCF {expected_outputs["manta_vcf"]} for {sg.id}')
                 input_dict['manta_vcf_input'] = expected_outputs.pop('manta_vcf')
                 input_dict['manta_index_index_input'] = expected_outputs.pop('manta_index')
             else:
                 # if the Manta VCF does not exist, run Manta as well
+                loguru.logger.info(
+                    f'Adding Manta job for {sg.id} because Scramble is being run and Manta VCF does not exist'
+                )
                 only_jobs.append('manta')
 
         # disable the caller jobs that are not in only_jobs by nulling their docker image

--- a/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
+++ b/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
@@ -80,7 +80,7 @@ def create_gather_sample_evidence_jobs(
                 # if the Manta VCF exists, use it as input and remove it from expected outputs
                 loguru.logger.info(f'Re-using existing Manta VCF {expected_outputs["manta_vcf"]} for {sg.id}')
                 input_dict['manta_vcf_input'] = expected_outputs.pop('manta_vcf')
-                input_dict['manta_index_index_input'] = expected_outputs.pop('manta_index')
+                input_dict['manta_vcf_index_input'] = expected_outputs.pop('manta_index')
             else:
                 # if the Manta VCF does not exist, run Manta as well
                 loguru.logger.info(

--- a/src/cpg_flow_gatk_sv/singlesample_workflow.py
+++ b/src/cpg_flow_gatk_sv/singlesample_workflow.py
@@ -52,7 +52,7 @@ class GatherSampleEvidence(stage.SequencingGroupStage):
         }
 
         # Caller's VCFs
-        for caller in utils.get_sv_callers():
+        for caller in utils.get_sv_callers(add_manta=True):
             outputs[f'{caller}_vcf'] = prefix / f'{sequencing_group.id}.{caller}.vcf.gz'
             outputs[f'{caller}_index'] = prefix / f'{sequencing_group.id}.{caller}.vcf.gz.tbi'
 

--- a/src/cpg_flow_gatk_sv/singlesample_workflow.py
+++ b/src/cpg_flow_gatk_sv/singlesample_workflow.py
@@ -64,6 +64,12 @@ class GatherSampleEvidence(stage.SequencingGroupStage):
                     if job in key:
                         new_expected[key] = path
 
+            if 'scramble' in only_jobs and 'manta' not in only_jobs:
+                # if Scramble is being run, but Manta is not, manta_vcf and index becomes a required input
+                # so we need to add them to the expected outputs
+                new_expected['manta_vcf'] = outputs['manta_vcf']
+                new_expected['manta_index'] = outputs['manta_index']
+
             outputs = new_expected
 
         return outputs

--- a/src/cpg_flow_gatk_sv/singlesample_workflow.py
+++ b/src/cpg_flow_gatk_sv/singlesample_workflow.py
@@ -4,8 +4,6 @@ single-sample components of the GATK SV workflow
 
 import argparse
 
-import loguru
-
 from cpg_flow import stage, targets, workflow
 from cpg_flow_gatk_sv import utils
 from cpg_flow_gatk_sv.jobs.CreateSampleBatches import create_sample_batches
@@ -59,21 +57,13 @@ class GatherSampleEvidence(stage.SequencingGroupStage):
             outputs[f'{caller}_index'] = prefix / f'{sequencing_group.id}.{caller}.vcf.gz.tbi'
 
         if only_jobs := config.config_retrieve(['workflow', self.name, 'only_jobs'], None):
-            loguru.logger.info(
-                f'GatherSampleEvidence: only running jobs: {only_jobs} for {sequencing_group.id}'
-            )
-            # If Scramble is being run, but Manta is not, manta_vcf and index becomes a required input
-            if 'scramble' in only_jobs and 'manta' not in only_jobs:
-                loguru.logger.info(
-                    f'Adding Manta to only_jobs for {sequencing_group.id} because Scramble is being run'
-                )
-                only_jobs.append('manta')
             # remove the expected outputs for the jobs that are not in only_jobs
             new_expected = {}
             for job in only_jobs:
                 for key, path in outputs.items():
                     if job in key:
                         new_expected[key] = path
+
             outputs = new_expected
 
         return outputs

--- a/src/cpg_flow_gatk_sv/singlesample_workflow.py
+++ b/src/cpg_flow_gatk_sv/singlesample_workflow.py
@@ -4,6 +4,8 @@ single-sample components of the GATK SV workflow
 
 import argparse
 
+import loguru
+
 from cpg_flow import stage, targets, workflow
 from cpg_flow_gatk_sv import utils
 from cpg_flow_gatk_sv.jobs.CreateSampleBatches import create_sample_batches
@@ -57,8 +59,14 @@ class GatherSampleEvidence(stage.SequencingGroupStage):
             outputs[f'{caller}_index'] = prefix / f'{sequencing_group.id}.{caller}.vcf.gz.tbi'
 
         if only_jobs := config.config_retrieve(['workflow', self.name, 'only_jobs'], None):
+            loguru.logger.info(
+                f'GatherSampleEvidence: only running jobs: {only_jobs} for {sequencing_group.id}'
+            )
             # If Scramble is being run, but Manta is not, manta_vcf and index becomes a required input
             if 'scramble' in only_jobs and 'manta' not in only_jobs:
+                loguru.logger.info(
+                    f'Adding Manta to only_jobs for {sequencing_group.id} because Scramble is being run'
+                )
                 only_jobs.append('manta')
             # remove the expected outputs for the jobs that are not in only_jobs
             new_expected = {}

--- a/src/cpg_flow_gatk_sv/utils.py
+++ b/src/cpg_flow_gatk_sv/utils.py
@@ -53,10 +53,10 @@ class CromwellJobSizes(Enum):
 
 
 @cache
-def get_sv_callers():
+def get_sv_callers(add_manta: bool = False):
     if only_jobs := config.config_retrieve(['workflow', 'GatherSampleEvidence', 'only_jobs'], None):
         callers = [caller for caller in SV_CALLERS if caller in only_jobs]
-        if 'scramble' in only_jobs and 'manta' not in only_jobs:
+        if 'scramble' in only_jobs and 'manta' not in only_jobs and add_manta:
             callers.append('manta')
         if not callers:
             loguru.logger.warning('No SV callers enabled')

--- a/src/cpg_flow_gatk_sv/utils.py
+++ b/src/cpg_flow_gatk_sv/utils.py
@@ -55,9 +55,9 @@ class CromwellJobSizes(Enum):
 @cache
 def get_sv_callers():
     if only_jobs := config.config_retrieve(['workflow', 'GatherSampleEvidence', 'only_jobs'], None):
-        if 'scramble' in only_jobs and 'manta' not in only_jobs:
-            only_jobs.append('manta')
         callers = [caller for caller in SV_CALLERS if caller in only_jobs]
+        if 'scramble' in only_jobs and 'manta' not in only_jobs:
+            callers.append('manta')
         if not callers:
             loguru.logger.warning('No SV callers enabled')
         return callers


### PR DESCRIPTION
# Purpose

  - Adds a boolean flag to the `get_sv_callers()` function to determine whether or not manta needs to be forced into the list of sv callers. This is the change required to get just scramble running and re-using an existing manta VCF.
  - See: https://batch.hail.populationgenomics.org.au/batches/624864/jobs/1
