### PR TITLE
Add references to genotypebatch

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.5
+  VERSION: 0.1.6
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.5
+Current Version: 0.1.6
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.5 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.6 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.5"
+version="0.1.6"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.5"
+current_version = "0.1.6"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/jobs/GenotypeBatch.py
+++ b/src/cpg_flow_gatk_sv/jobs/GenotypeBatch.py
@@ -53,6 +53,16 @@ def create_genotypebatch_jobs(
         ]
     }
 
+    # add references
+    input_dict |= utils.get_references(
+        [
+            'primary_contigs_list',
+            'bin_exclude',
+            'seed_cutoffs',
+            'pesr_exclude_list',
+        ]
+    )
+
     return utils.add_gatk_sv_jobs(
         dataset=cohort.dataset,
         wfl_name='GenotypeBatch',


### PR DESCRIPTION
# Purpose

  - During migration the `get_references` call was not migrated in GenotypeBatch

## Proposed Changes

  - re-adds the expected config files, matching the cpg_workflows implementation [here](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gatk_sv/gatk_sv_multisample.py#L733)

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
