### PR TITLE
Squash two bugs

### DIFF
--- a/src/cpg_flow_gatk_sv/jobs/SplitAnnotatedSvVcf.py
+++ b/src/cpg_flow_gatk_sv/jobs/SplitAnnotatedSvVcf.py
@@ -50,7 +50,7 @@ def create_split_vcf_by_dataset_job(
             -S {local_sgids} \\
             -Oz \\
             -o {job.output['vcf.bgz']} \\
-            --W=tbi \\
+            -W=tbi \\
             {local_vcf}
         """,
     )

--- a/src/cpg_flow_gatk_sv/scripts/annotate_cohort.py
+++ b/src/cpg_flow_gatk_sv/scripts/annotate_cohort.py
@@ -190,7 +190,7 @@ def annotate_cohort_sv(vcf_path: str, out_mt_path: str, gencode_gz: str, checkpo
     )
 
     # get the Gene-Symbol mapping dict
-    gene_id_mapping = parse_gtf_from_local(gencode_gz)[0]
+    gene_id_mapping = parse_gtf_from_local(gencode_gz)
 
     # OK, NOW IT'S BUSINESS TIME
     conseq_predicted_gene_cols = [


### PR DESCRIPTION
# Purpose

- Fixes [this](https://batch.hail.populationgenomics.org.au/batches/626604/jobs/1) issue - the whole GTF is being passed as a single object now that Hail memory problems are being solved. This syntax was not correctly updated
- Fixes [this](https://batch.hail.populationgenomics.org.au/batches/626604/jobs/2) - the BCFtools syntax was incorrectly abbreviated from `--write-index` to `--W` (should be a single-hyphen `-W`)
