### PR TITLE
Drop stage stage suffixes

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.9
+  VERSION: 0.1.10
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.9
+Current Version: 0.1.10
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.9 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.10 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.9"
+version="0.1.10"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.9"
+current_version = "0.1.10"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/config_template.toml
+++ b/src/cpg_flow_gatk_sv/config_template.toml
@@ -1,13 +1,13 @@
 [workflow]
 name = 'gatk_sv'
 
+sequencing_type = 'genome'
+
 gatk_sv_commit = 'dc145a52f76a6f425ac3f481171040e78c0cfeea'
 
 check_expected_outputs = true
 
 min_batch_size = 10
-
-sequencing_type = 'genome'
 
 ref_fasta = 'gs://cpg-common-main/references/hg38/v0/dragen_reference/Homo_sapiens_assembly38_masked.fasta'
 
@@ -84,7 +84,8 @@ gatk_docker_pesr_override = "australia-southeast1-docker.pkg.dev/cpg-common/imag
 genomes_in_the_cloud_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/genomes-in-the-cloud:2.3.2-1510681135"
 gq_recalibrator_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:mw-tb-form-sv-filter-training-data-899360a"
 linux_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/ubuntu1804"
-manta_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/manta:2023-09-14-v0.28.3-beta-3f22f94d"
+#manta_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/manta:2023-09-14-v0.28.3-beta-3f22f94d"
+manta_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/manta_no_rrr_for_ins:1.6.0-1"
 samtools_cloud_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/samtools-cloud:2024-10-25-v0.29-beta-5ea22a52"
 scramble_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/scramble:2024-10-25-v0.29-beta-5ea22a52"
 str = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/str:2023-05-23-v0.27.3-beta-e537bdd6"

--- a/src/cpg_flow_gatk_sv/multisample_workflow.py
+++ b/src/cpg_flow_gatk_sv/multisample_workflow.py
@@ -8,10 +8,8 @@ import loguru
 
 from cpg_flow import stage, targets, workflow
 from cpg_flow_gatk_sv import utils
-
 from cpg_flow_gatk_sv.jobs.AnnotateCohort import create_annotate_cohort_job
 from cpg_flow_gatk_sv.jobs.AnnotateDataset import create_annotate_dataset_jobs
-from cpg_flow_gatk_sv.jobs.MtToEs import create_mt_to_es_job
 from cpg_flow_gatk_sv.jobs.AnnotateVcf import create_svannotate_jobs
 from cpg_flow_gatk_sv.jobs.AnnotateWithStrvctvre import create_strvctvre_jobs
 from cpg_flow_gatk_sv.jobs.ClusterBatch import create_cluster_batch_jobs
@@ -27,11 +25,11 @@ from cpg_flow_gatk_sv.jobs.GenotypeBatch import create_genotypebatch_jobs
 from cpg_flow_gatk_sv.jobs.JoinRawCalls import create_joinrawcalls_jobs
 from cpg_flow_gatk_sv.jobs.MakeCohortVcf import create_makecohortvcf_jobs
 from cpg_flow_gatk_sv.jobs.MergeBatchSites import create_mergebatchsites_jobs
+from cpg_flow_gatk_sv.jobs.MtToEs import create_mt_to_es_job
 from cpg_flow_gatk_sv.jobs.SpiceUpSvIds import create_spicy_jobs
 from cpg_flow_gatk_sv.jobs.SplitAnnotatedSvVcf import create_split_vcf_by_dataset_job
 from cpg_flow_gatk_sv.jobs.SVConcordance import create_sv_concordance_jobs
 from cpg_flow_gatk_sv.jobs.TrainGCNV import add_train_gcnv_jobs
-
 from cpg_utils import Path, config
 
 


### PR DESCRIPTION
# Purpose

  - This corrects a migration issue where I suffixed the Stage names with "Stage", so I could lazily write a tighter import block. The resulting issue is that the output paths for each Stage will be different to pre-migration, and a bunch of stages would repeat work

## Proposed Changes

  - Pads out the import block, importing each method exactly
  - Removes the "Stage" suffix from all Stage names, resuming previous behaviour

n.b. there is a batch running [here](https://batch.hail.populationgenomics.org.au/batches/626611) - _if_ this finishes, the GATK-SV pipeline will have run end-to-end (in parts). If that workflow fails, this workflow will need other patches prior to merging this change