### PR TITLE
Explicit deletion of variant calling tmp

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.11
+  VERSION: 0.1.12
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.11
+Current Version: 0.1.12
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.11 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.12 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.11"
+version="0.1.12"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.11"
+current_version = "0.1.12"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
+++ b/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
@@ -1,8 +1,10 @@
 from typing import TYPE_CHECKING, Any
 
+import os
+
 from cpg_flow import targets
 from cpg_flow_gatk_sv import utils
-from cpg_utils import Path, config, to_path
+from cpg_utils import Path, config, hail_batch, to_path
 
 if TYPE_CHECKING:
     from hailtop.batch.job import BashJob
@@ -92,7 +94,7 @@ def create_gather_sample_evidence_jobs(
     # this is used to determine how often to poll Cromwell for completion status
     # we alter the per-sample maximum to be between 5 and 30 minutes for this
     # long-running job, so samples poll on different intervals, spreading load
-    return utils.add_gatk_sv_jobs(
+    gather_sample_evidence_jobs = utils.add_gatk_sv_jobs(
         dataset=sg.dataset,
         wfl_name=STAGE_NAME,
         input_dict=input_dict,
@@ -101,3 +103,13 @@ def create_gather_sample_evidence_jobs(
         labels=billing_labels,
         job_size=utils.CromwellJobSizes.LARGE,
     )
+
+    deletion_job = hail_batch.get_batch().new_bash_job(f'Delete GatherSampleEvidence tmp for {sg.id}')
+    deletion_job.image(config.config_retrieve(['workflow', 'driver_image']))
+    # set explicit dependency - no variant calling success, no deletion
+    deletion_job.depends_on(*gather_sample_evidence_jobs)
+    tmp_bucket = config.config_retrieve(['storage', 'default', 'tmp'])
+    delete_path = os.path.join(tmp_bucket, 'cromwell', STAGE_NAME, sg.id)
+    deletion_job.command(f'gcloud storage rm -r {delete_path}')
+
+    return [*gather_sample_evidence_jobs, deletion_job]


### PR DESCRIPTION
# Purpose

  - GatherSampleEvidence creates a ton of temporary data, which is not explicitly cleaned up after successful stage completion. With current retention policies the lack of cleanup leads to substantial costs.
  
## Proposed Changes

  - Adds an explicit step after the GatherSampleEvidence step completes, deleting the 'intermediate output folder' for the run
  - This folder path isn't generated in this workflow, instead it's created a few steps down in [cpg-utils](https://github.com/populationgenomics/cpg-utils/blob/main/cpg_utils/cromwell.py#L219-L223), but this creates the same path (current dataset-tmp/cromwell/SG_ID)
  - This step in particular generates a ton of `tmp`, and is named such that it is unique to the sequencing group, so we can safely delete all contents without impacting any other runs
  - Deletion is only triggered if the calling step runs successfully