### PR TITLE
One multicohort Stage for all temp deletions

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.12
+  VERSION: 0.1.13
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.12
+Current Version: 0.1.13
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.12 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.13 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.12"
+version="0.1.13"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.12"
+current_version = "0.1.13"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/config_template.toml
+++ b/src/cpg_flow_gatk_sv/config_template.toml
@@ -219,6 +219,9 @@ mem_gb = 32
 disk_gb = 50
 cpu = 2
 
+[resource_overrides.JoinRawCalls.runtime_attr_svcluster]
+mem_gb = 16
+
 #[hail]
 #billing_project = "test-vcgs-dataset"
 #delete_scratch_on_exit = true

--- a/src/cpg_flow_gatk_sv/jobs/DeleteSingleSampleTemp.py
+++ b/src/cpg_flow_gatk_sv/jobs/DeleteSingleSampleTemp.py
@@ -1,0 +1,26 @@
+import zoneinfo
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from cpg_utils import Path, config, hail_batch
+
+if TYPE_CHECKING:
+    from hailtop.batch.job import BashJob
+
+
+def delete_temp_data_recursive(temp_path: Path, logfile: Path) -> 'BashJob':
+    """
+    takes the path used to write SingleSample-calling temp data intermediatesm, runs a recursive deletion on that path
+    """
+
+    deletion_job = hail_batch.get_batch().new_bash_job('Delete SingleSample Temporary Files')
+    deletion_job.image(config.config_retrieve(['workflow', 'driver_image']))
+    deletion_job.command(f'gcloud storage rm -r {temp_path!s}')
+
+    # generate a log file with the deletion timestamp
+    # this is generated within the job so that we can ensure the deletion was successful, or no log is written
+    timestamp = datetime.now(tz=zoneinfo.ZoneInfo('Australia/Brisbane')).strftime('%Y-%m-%d %H:%M:%S')
+    deletion_job.command(f'echo "Deleted {temp_path!s}, date {timestamp}" > {deletion_job.output}')
+    hail_batch.get_batch().write_output(deletion_job.output, logfile)
+
+    return deletion_job

--- a/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
+++ b/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
@@ -1,9 +1,8 @@
-import os
 from typing import TYPE_CHECKING, Any
 
 from cpg_flow import targets
 from cpg_flow_gatk_sv import utils
-from cpg_utils import Path, config, hail_batch, to_path
+from cpg_utils import Path, config, to_path
 
 if TYPE_CHECKING:
     from hailtop.batch.job import BashJob
@@ -93,7 +92,7 @@ def create_gather_sample_evidence_jobs(
     # this is used to determine how often to poll Cromwell for completion status
     # we alter the per-sample maximum to be between 5 and 30 minutes for this
     # long-running job, so samples poll on different intervals, spreading load
-    gather_sample_evidence_jobs = utils.add_gatk_sv_jobs(
+    return utils.add_gatk_sv_jobs(
         dataset=sg.dataset,
         wfl_name=STAGE_NAME,
         input_dict=input_dict,
@@ -102,13 +101,3 @@ def create_gather_sample_evidence_jobs(
         labels=billing_labels,
         job_size=utils.CromwellJobSizes.LARGE,
     )
-
-    deletion_job = hail_batch.get_batch().new_bash_job(f'Delete GatherSampleEvidence tmp for {sg.id}')
-    deletion_job.image(config.config_retrieve(['workflow', 'driver_image']))
-    # set explicit dependency - no variant calling success, no deletion
-    deletion_job.depends_on(*gather_sample_evidence_jobs)
-    tmp_bucket = config.config_retrieve(['storage', 'default', 'tmp'])
-    delete_path = os.path.join(tmp_bucket, 'cromwell', STAGE_NAME, sg.id)
-    deletion_job.command(f'gcloud storage rm -r {delete_path}')
-
-    return [*gather_sample_evidence_jobs, deletion_job]


### PR DESCRIPTION
# Purpose

  - I added a step into GatherSampleEvidence which deleted a single sample's tempdir upon successful completion of calling
  - That targeted the wrong directory name, using the CPG ID instead of the cromwell run ID
  - As a result, no cleanup was done and things failed

## Proposed Changes

  - Add a follow-on stage, to come after all single-sample calling has completed
  - Delete the whole `bucket/temp/GatherSampleEvidence/*` root, removing temp data for all samples
  - Stage is MultiCohort, so will only run once GatherSampleEvidence has concluded across the whole MC - should not be used when multiple independent MCs are running variant calling (we don't do this)

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [x] Linting checks pass
