### PR TITLE
Remove sv_pipeline_qc_docker from ClusterBatch inputs

### DIFF
--- a/src/cpg_flow_gatk_sv/jobs/ClusterBatch.py
+++ b/src/cpg_flow_gatk_sv/jobs/ClusterBatch.py
@@ -34,7 +34,6 @@ def create_cluster_batch_jobs(
         'linux_docker': config.config_retrieve(['images', 'linux_docker']),
         'sv_base_mini_docker': config.config_retrieve(['images', 'sv_base_mini_docker']),
         'sv_pipeline_docker': config.config_retrieve(['images', 'sv_pipeline_docker']),
-        'sv_pipeline_qc_docker': config.config_retrieve(['images', 'sv_pipeline_qc_docker']),
         'contig_list': config.config_retrieve(['references', 'primary_contigs_list']),
         'depth_exclude_intervals': config.config_retrieve(['references', 'depth_exclude_list']),
         'pesr_exclude_intervals': config.config_retrieve(['references', 'pesr_exclude_list']),


### PR DESCRIPTION
# Purpose

  - Remove the `sv_pipeline_qc_docker` input from ClusterBatch job submission

The Cromwell job got upset with this extra input: https://batch.hail.populationgenomics.org.au/batches/631455/jobs/7992

```
"WARNING: Unexpected input provided: ClusterBatch.sv_pipeline_qc_docker (expected inputs: [ClusterBatch.contig_subset_list, ClusterBatch.ClusterBatchMetrics.runtime_attr_melt_metrics, ... ])
```