### PR TITLE
Add resource override config option for JoinRawCalls.SVCluster

### DIFF
--- a/src/cpg_flow_gatk_sv/config_template.toml
+++ b/src/cpg_flow_gatk_sv/config_template.toml
@@ -180,6 +180,9 @@ run_module_metrics = false
 [resource_overrides.ClusterBatch]
 run_module_metrics = false
 
+[resource_overrides.JoinRawCalls.runtime_attr_svcluster]
+mem_gb = 3.75
+
 [resource_overrides.GenerateBatchMetrics]
 run_module_metrics = false
 


### PR DESCRIPTION
# Purpose

  - Add a config default for overriding the resources allocated to the JoinRawCalls SVCluster task
  - Resource overrides set in JoinRawCalls [here](https://github.com/populationgenomics/gatk-sv/blob/890582922bccb4b651275506a34311c949417f6c/wdl/JoinRawCalls.wdl#L106)
  - Resource overrides used in SVCluster [here](https://github.com/populationgenomics/gatk-sv/blob/890582922bccb4b651275506a34311c949417f6c/wdl/TasksClusterBatch.wdl#L68)


Increasing this memory may help with resolving errors seen in this workflow, e.g.: 
https://batch.hail.populationgenomics.org.au/batches/631499/jobs/538