### PR TITLE
Add full paths to genome tracks as a config entry (for FilterGenotypes)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.13
+  VERSION: 0.1.14
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.13
+Current Version: 0.1.14
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.13 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.14 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.13"
+version="0.1.14"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.13"
+current_version = "0.1.14"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/config_template.toml
+++ b/src/cpg_flow_gatk_sv/config_template.toml
@@ -52,20 +52,20 @@ protein_coding_gtf = "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resourc
 
 wgd_scoring_mask = "gs://cpg-common-main/references/hg38/v0/sv-resources/resources/v1/wgd_scoring_mask.hg38.gnomad_v3.bed"
 
-# genome tracks are a list of CPG config keys
+# genome tracks are a list of paths to files
 genome_tracks = [
-    'recalibrate_gq_repeatmasker',
-    'recalibrate_gq_segmental_dups',
-    'recalibrate_gq_simple_reps',
-    'recalibrate_gq_umap_s100',
-    'recalibrate_gq_umap_s24',
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-RepeatMasker.bed.gz",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-Segmental-Dups.bed.gz",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-Simple-Repeats.bed.gz",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s100.bed.gz",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s24.bed.gz",
 ]
 genome_tracks_index = [
-    'recalibrate_gq_repeatmasker_index',
-    'recalibrate_gq_segmental_dups_index',
-    'recalibrate_gq_simple_reps_index',
-    'recalibrate_gq_umap_s100_index',
-    'recalibrate_gq_umap_s24_index',
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-RepeatMasker.bed.gz.tbi",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-Segmental-Dups.bed.gz.tbi",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-Simple-Repeats.bed.gz.tbi",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s100.bed.gz.tbi",
+    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s24.bed.gz.tbi",
 ]
 
 bin_exclude = "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/bin_exclude.hg38.gatkcov.bed.gz"

--- a/src/cpg_flow_gatk_sv/config_template.toml
+++ b/src/cpg_flow_gatk_sv/config_template.toml
@@ -60,13 +60,6 @@ genome_tracks = [
     "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s100.bed.gz",
     "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s24.bed.gz",
 ]
-genome_tracks_index = [
-    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-RepeatMasker.bed.gz.tbi",
-    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-Segmental-Dups.bed.gz.tbi",
-    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38-Simple-Repeats.bed.gz.tbi",
-    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s100.bed.gz.tbi",
-    "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/ucsc-genome-tracks/hg38_umap_s24.bed.gz.tbi",
-]
 
 bin_exclude = "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/bin_exclude.hg38.gatkcov.bed.gz"
 depth_exclude_list = "gs://cpg-common-main/references/gatk-sv/hg38/v0/sv-resources/resources/v1/depth_blacklist.sorted.bed.gz"


### PR DESCRIPTION
# Purpose

  - Faulty liftover when I was trying to have a fully self-contained config file

## Proposed Changes

  - Instead of containing a list of keys (which then required looking up in a separate part of the config), this list contains the full paths to the required files
  - Alternative to #28 (which still has a dependency on the global config)

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
