### PR TITLE
Annotatevcf remove use hail

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.14
+  VERSION: 0.1.15
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.14
+Current Version: 0.1.15
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.14 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.15 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.14"
+version="0.1.15"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.14"
+current_version = "0.1.15"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/jobs/AnnotateVcf.py
+++ b/src/cpg_flow_gatk_sv/jobs/AnnotateVcf.py
@@ -22,7 +22,6 @@ def create_svannotate_jobs(
         'external_af_population': config.config_retrieve(['references', 'external_af_population']),
         'external_af_ref_prefix': config.config_retrieve(['references', 'external_af_ref_bed_prefix']),
         'external_af_ref_bed': config.config_retrieve(['references', 'gnomad_sv']),
-        'use_hail': False,
         'noncoding_bed': config.config_retrieve(['references', 'noncoding_bed']),
         'protein_coding_gtf': config.config_retrieve(['references', 'protein_coding_gtf']),
         'contig_list': config.config_retrieve(['references', 'primary_contigs_list']),


### PR DESCRIPTION
# Purpose

  - Remove the extra input `use_hail` which is no longer used by this workflow


```
"WARNING: Unexpected input provided: AnnotateVcf.use_hail (expected inputs: [AnnotateVcf.ConcatVcfs.sites_only, AnnotateVcf.ConcatVcfs.sort_vcf_list, AnnotateVcf.ped_file, AnnotateVcf.runtime_attr_compute_AFs, AnnotateVcf.gatk_docker, AnnotateVcf.promoter_window, AnnotateVcf.external_af_population, AnnotateVcf.external_af_ref_prefix, AnnotateVcf.runtime_attr_svannotate, AnnotateVcf.protein_coding_gtf, AnnotateVcf.sample_keep_list, AnnotateVcf.runtime_attr_modify_vcf, AnnotateVcf.sv_per_shard, AnnotateVcf.runtime_attr_split_query_vcf, AnnotateVcf.vcf, AnnotateVcf.runtime_attr_scatter_vcf, AnnotateVcf.ConcatVcfs.naive, AnnotateVcf.sv_base_mini_docker, AnnotateVcf.runtime_attr_preconcat, AnnotateVcf.noncoding_bed, AnnotateVcf.sample_pop_assignments, AnnotateVcf.ConcatVcfs.generate_index, AnnotateVcf.prefix, AnnotateVcf.par_bed, AnnotateVcf.max_breakend_as_cnv_length, AnnotateVcf.allosomes_list, AnnotateVcf.sv_pipeline_docker, AnnotateVcf.runtime_attr_fix_header, AnnotateVcf.runtime_attr_split_ref_bed, AnnotateVcf.runtime_attr_bedtools_closest, AnnotateVcf.svannotate_additional_args, AnnotateVcf.contig_list, AnnotateVcf.external_af_ref_bed, AnnotateVcf.runtime_attr_select_matched_svs, AnnotateVcf.runtime_attr_concat, AnnotateVcf.runtime_attr_subset_vcf_by_samples_list])"
```