### PR TITLE
Remove singlesample delete temp objects job

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.19
+  VERSION: 0.1.20
   IMAGE_NAME: cpg-flow-gatk-sv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.19
+Current Version: 0.1.20
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.19 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.20 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.19"
+version="0.1.20"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.19"
+current_version = "0.1.20"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
+++ b/src/cpg_flow_gatk_sv/jobs/GatherSampleEvidence.py
@@ -1,9 +1,8 @@
-import os
 from typing import TYPE_CHECKING, Any
 
 from cpg_flow import targets
 from cpg_flow_gatk_sv import utils
-from cpg_utils import Path, config, hail_batch, to_path
+from cpg_utils import Path, config, to_path
 
 if TYPE_CHECKING:
     from hailtop.batch.job import BashJob


### PR DESCRIPTION
# Purpose

  - Remove the "deletion" job from the GatherSampleEvidence stage of the single sample workflow
  - This job was failing because the namespace for the tmp files relies on the cromwell WFID, which is not accessible when the jobs are queued by the driver
  - Example [here](https://batch.hail.populationgenomics.org.au/batches/633053/jobs/117)

## Proposed Changes

  - For now, just remove the stage to prevent the failures
  - Future scope should try re-implementing this but using the WFID somehow.

