### PR TITLE
Es index analysis output fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.137.cpg1-2 AS basic
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.25
+ENV VERSION=0.1.26
 
 WORKDIR /cpg_flow_gatk_sv
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.25
+Current Version: 0.1.26
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.25 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.26 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.25"
+version="0.1.26"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -120,7 +120,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.25"
+current_version = "0.1.26"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/multisample_workflow.py
+++ b/src/cpg_flow_gatk_sv/multisample_workflow.py
@@ -902,7 +902,7 @@ class AnnotatedDatasetMtToSvVcf(stage.DatasetStage):
 @stage.stage(
     required_stages=[AnnotateDataset],
     analysis_type='es-index',
-    analysis_keys=['index_name'],
+    analysis_keys=['done_flag'],
     update_analysis_meta=lambda x: {'seqr-dataset-type': 'SV'},  # noqa: ARG005
 )
 class MtToEs(stage.DatasetStage):


### PR DESCRIPTION
# Purpose

  - To stay compatible with Metamist 7.13.x, write the `done_flag` path to the es-index analysis record's `output`, rather than the name of the es-index, since Metamist analyses now only work with analysis outputs that have a path protocol, like `'gs://'`. 
    - Due to change: https://github.com/populationgenomics/metamist/pull/1171 

Note - seqr sync methods will need to be updated to trim the new path down to just the es-index name.