### PR TITLE
Allow more than 32 exclusion lists to be concatenated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_hail_gcloud:0.2.138.cpg1-1 AS basic
 
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV VERSION=0.1.27
+ENV VERSION=0.1.28
 
 WORKDIR /cpg_flow_gatk_sv
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GATK-SV, in CPG-Flow
 
-Current Version: 0.1.27
+Current Version: 0.1.28
 
 This repository contains the GATK-SV workflow, which is a wrapper around the [GATK-SV Cromwell workflow](https://github.com/broadinstitute/gatk-sv). It has been migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/tree/main/cpg_workflows/stages/gatk_sv). This has been generated as part of the migration from Production-Pipelines's CPG_workflows framework, to the separate CPG-Flow.
 
@@ -59,7 +59,7 @@ This is designed to be run using analysis-runner, using a fully containerised in
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.27 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gatk-sv:0.1.28 \
     --dataset DATASET \
     --description 'GATK-SV, CPG-flow' \
     -o gatk-sv_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description="CPG-Flow implementation of the GATK-SV workflow"
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.27"
+version="0.1.28"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -119,7 +119,7 @@ hail = ["hail"]
 "src/cpg_flow_gatk_sv/multisample_workflow.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.27"
+current_version = "0.1.28"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_flow_gatk_sv/jobs/CombineExclusionLists.py
+++ b/src/cpg_flow_gatk_sv/jobs/CombineExclusionLists.py
@@ -13,6 +13,15 @@ def create_combine_exclusion_lists_job(
     job = hail_batch.get_batch().new_bash_job('Concatenate all sample exclusion files')
     job.image(config.config_retrieve(['workflow', 'driver_image']))
     hail_batch.authenticate_cloud_credentials_in_job(job)
-    job.command(f'gcloud storage objects compose {" ".join(file_list)} {output}')
+
+    # Gcloud compose allows concatenation of up to 32 files, more than this needs chunking
+    intermediate_files = []
+    for i in range(0, len(file_list), 32):
+        chunk_files = file_list[i : i + 32]
+        intermediate_output = f'{output}_intermediate_{i // 32}'
+        job.command(f'gcloud storage objects compose {" ".join(chunk_files)} {intermediate_output}')
+        intermediate_files.append(intermediate_output)
+
+    job.command(f'gcloud storage objects compose {" ".join(intermediate_files)} {output}')
 
     return job


### PR DESCRIPTION
# Purpose

  - Gcloud compose caps out at 32 files, but there's exclusion one file per cohort, and we now have 33 input cohorts. So this concatenation method needs updating to handle files in chunks of up to 32. 

## Proposed Changes

  - Still using Gcloud compose, concatenate the first 32 files into an intermediate file, then concatenate the rest 

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
